### PR TITLE
Document dataset retrieval and DATA_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ The instructions below assume you are using **Windows PowerShell**.
 
 - Python 3.8 or newer installed and added to your PATH
 - [Optional] Git for cloning the repository
-- The "Credit Card Fraud Detection" dataset (from Kaggle) saved as `data\data_raw.csv`
+- The "Credit Card Fraud Detection" dataset saved as `data\data_raw.csv`. You can either
+  - download it from Kaggle and place the file at that location, or
+  - run `git lfs pull` if you cloned the repository with Git LFS enabled.
+  - if you keep the file elsewhere, set the `DATA_PATH` environment variable
+    to the full path before running the training script.
 
 ## 1. Set up a virtual environment
 ```powershell
@@ -51,6 +55,7 @@ The response contains the predicted label and fraud probability.
 - `MODEL_NAME` – name of the registered model (`fraud_detector`)
 - `DECISION_THRESHOLD` – threshold for predicting fraud (0.640 by default)
 - `API_KEY` – key required when calling the API (`dev-key` by default)
+- `DATA_PATH` – path to `data_raw.csv` used for training (defaults to `data/data_raw.csv`)
 
 Set them in PowerShell using `$env:VAR = 'value'` before running the training script or API server.
 

--- a/mlops/train_and_register.py
+++ b/mlops/train_and_register.py
@@ -18,7 +18,12 @@ import cloudpickle
 # -----------------------------
 # Config
 # -----------------------------
-DATA_PATH = Path(__file__).resolve().parents[1] / "data" / "data_raw.csv"
+DATA_PATH = Path(
+    os.getenv(
+        "DATA_PATH",
+        str(Path(__file__).resolve().parents[1] / "data" / "data_raw.csv"),
+    )
+)
 MODEL_NAME = os.getenv("MODEL_NAME", "fraud_detector")
 DECISION_THRESHOLD = float(os.getenv("DECISION_THRESHOLD", 0.640))
 


### PR DESCRIPTION
## Summary
- explain how to download `data_raw.csv` either via Kaggle or `git lfs`
- allow training script to override dataset path with `DATA_PATH` env var

## Testing
- `python -m py_compile mlops/train_and_register.py`

------
https://chatgpt.com/codex/tasks/task_e_688a3bbb9fa483318d1a966626f67867