### PR TITLE
Add tests for MLflow wrapper and FastAPI

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,33 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+from fastapi.testclient import TestClient
+import mlops.api_main as api_main
+
+class DummyModel:
+    def predict(self, df: pd.DataFrame):
+        return pd.DataFrame({"probability": [0.4] * len(df), "label": [1] * len(df)})
+
+class DummyClient:
+    def get_latest_versions(self, name, stages=None):
+        return [type("mv", (), {"version": "1"})()]
+
+def _setup(monkeypatch):
+    monkeypatch.setattr(api_main.mlflow.pyfunc, "load_model", lambda uri: DummyModel())
+    monkeypatch.setattr(api_main.mlflow.tracking, "MlflowClient", lambda: DummyClient())
+
+
+def test_predict_endpoint(monkeypatch):
+    _setup(monkeypatch)
+    with TestClient(api_main.app) as client:
+        payload = {feat: 0.0 for feat in api_main.FEATURES}
+        response = client.post("/predict", json=payload, headers={"x-api-key": "dev-key"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["model_name"] == api_main.MODEL_NAME
+        assert data["predictions"][0]["fraud_probability"] == 0.4
+        assert data["predictions"][0]["predicted_label"] == 1

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,0 +1,45 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+from mlops.train_and_register import FraudModelWrapper
+
+ARTIFACTS = {
+    "clf": "artifacts/clf.pkl",
+    "scaler": "artifacts/scaler.pkl",
+    "feature_order": "artifacts/feature_order.json",
+    "threshold": "artifacts/threshold.txt",
+    "trained_features": "artifacts/trained_features.json",
+}
+
+def _load_wrapper():
+    wrapper = FraudModelWrapper()
+    ctx = type("ctx", (), {"artifacts": ARTIFACTS})()
+    wrapper.load_context(ctx)
+    return wrapper
+
+def test_preprocess_adds_engineered_columns():
+    wrapper = _load_wrapper()
+    with open(ARTIFACTS["feature_order"]) as f:
+        features = json.load(f)
+    data = {feat: 0.0 for feat in features}
+    df = pd.DataFrame([data])
+    processed = wrapper._preprocess(df)
+    assert list(processed.columns) == wrapper.trained_features
+    assert "Amount_Time" in processed.columns
+    assert "V1_V2" in processed.columns
+    assert "V3_V4" in processed.columns
+
+
+def test_wrapper_predict_returns_dataframe():
+    wrapper = _load_wrapper()
+    with open(ARTIFACTS["feature_order"]) as f:
+        features = json.load(f)
+    data = {feat: 0.0 for feat in features}
+    df = pd.DataFrame([data])
+    result = wrapper.predict(None, df)
+    assert list(result.columns) == ["probability", "label"]
+    assert len(result) == 1


### PR DESCRIPTION
## Summary
- add wrapper and API tests
- use TestClient for predict endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a3d8ae2308331a0f7803a52361a84