### PR TITLE
Remove unused cloudpickle import

### DIFF
--- a/mlops/train_and_register.py
+++ b/mlops/train_and_register.py
@@ -13,7 +13,6 @@ from imblearn.over_sampling import SMOTE
 
 import mlflow
 import mlflow.pyfunc
-import cloudpickle
 
 # -----------------------------
 # Config


### PR DESCRIPTION
## Summary
- tidy dependency usage in `mlops/train_and_register.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a45ea2f908331a161f8fc061ab0bc