### PR TITLE
chore: keep Docker configs in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,8 +31,6 @@ mlartifacts/
 
 # Docker
 .dockerignore
-Dockerfile*
-docker-compose*.yml
 
 # Documentation
 README.md


### PR DESCRIPTION
## Summary
- ensure Dockerfiles and docker-compose configs are sent with Docker build by removing their entries from .dockerignore

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pkg_resources')*


------
https://chatgpt.com/codex/tasks/task_e_6891f85824048331b37afc8aa32d6938